### PR TITLE
Fix replace's swapped arguments

### DIFF
--- a/src/main/java/world/bentobox/dimensionaltrees/events/TreeGrowEvent.java
+++ b/src/main/java/world/bentobox/dimensionaltrees/events/TreeGrowEvent.java
@@ -49,7 +49,7 @@ public class TreeGrowEvent implements Listener {
             return;
         }
         // Verify the sapling is in the settings list
-        if (!treeTypes().contains(e.getLocation().getBlock().getType().name().replace("", "_SAPLING").toLowerCase())) {
+        if (!treeTypes().contains(e.getLocation().getBlock().getType().name().replace("_SAPLING", "").toLowerCase())) {
             return;
         }
 


### PR DESCRIPTION
Was working on a fork and noticed this.  sapling.replace("", "_sapling") == "_saplingo_saplinga_saplingk_sapling__saplings_saplinga_saplingp_saplingl_saplingi_saplingn_saplingg_sapling".
sapling.replace("_sapling", "") == "oak".